### PR TITLE
Adding support for a file of labels on "out" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Set the status message for `concourse-ci` context on specified pull request.
 
 * `label`: *Optional.* A label to add to the pull request. Accepts one label or an array of labels.
 
+* `label_file`: *Optional.* A file containing a comma delimited list of labels to be added to the pull request.
+
 ## Example pipeline
 
 Please see this repo's [pipeline](https://github.com/jtarchie/pullrequest-resource/blob/master/.concourse.yml) for a perfect example.

--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -83,6 +83,14 @@ module Commands
         metadata << { 'name' => 'label', 'value' => params.label }
       end
 
+      if params.label_file
+        label_path = File.join(destination, params.label_file)
+        labels = File.read(label_path, encoding: Encoding::UTF_8)
+        labels_array = labels.split(',')
+        Octokit.add_labels_to_an_issue(input.source.repo, id, labels_array)
+        metadata << { 'name' => 'label', 'value' => labels_array }
+      end
+
       if params.merge.method
         commit_msg = if params.merge.commit_msg
                        commit_path = File.join(destination, params.merge.commit_msg)

--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -80,7 +80,7 @@ module Commands
                   [params.label]
                 end
         Octokit.add_labels_to_an_issue(input.source.repo, id, label)
-        metadata << { 'name' => 'label', 'value' => params.label }
+        metadata << { 'name' => 'label', 'value' => label }
       end
 
       if params.label_file

--- a/spec/commands/out_spec.rb
+++ b/spec/commands/out_spec.rb
@@ -211,7 +211,7 @@ describe Commands::Out do
                              'metadata' => [
                                { 'name' => 'status', 'value' => 'success' },
                                { 'name' => 'url', 'value' => 'http://example.com' },
-                               { 'name' => 'label', 'value' => 'test_label' },
+                               { 'name' => 'label', 'value' => ['test_label'] },
                              ])
       end
     end


### PR DESCRIPTION
This allows the out command to take a file containing a comma delimitated of labels to be added to the pull request. 