### PR TITLE
Add switch so that we will only see community PRs in a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ resource_types:
 * `authorship_restriction`: *Optional*, default false.  If set to `true`, will only
   return PRs created by someone who is a collaborator, repo owner, or organization member.
 
+* `community_only`: *Optional*, default false.  The opposite of `authorship_restriction` -
+  if set to true, will only return PRs created by someone who is not a collaborator, repo owner,
+  or organization member.
+
 * `label`: *Optional.* If set to a string it will only return pull requests that have been
 marked with that specific label. It is case insensitive.
 

--- a/assets/lib/filters/approval.rb
+++ b/assets/lib/filters/approval.rb
@@ -14,6 +14,9 @@ module Filters
       if @input.source.authorship_restriction
         @pull_requests.delete_if { |x| !x.author_associated? }
       end
+      if @input.source.community_only
+        @pull_requests.delete_if { |x| x.author_associated? }
+      end
 
       @pull_requests
     end


### PR DESCRIPTION
This will be useful for us when we want to do things on community PRs - for instance, approve them to run through our CI system by hand instead of automatically, or autoassign them, or comment on them.  :)